### PR TITLE
Add all packagelock files to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,14 @@ dist
 
 # TernJS port file
 .tern-port
+
+# MacOS DS Store
+.DS_Store
+
+# Package Lock
+package-lock.json
+krush/package-lock.json
+server/package-lock.json
+
+#Temp (for Bryan)
+TEMP_HOLD


### PR DESCRIPTION
Adding packgelock files from all paths to the `.gitignore` file so that when we run installs locally, they're not being included when they're merged to the main branch.